### PR TITLE
Set maximum parallelism to 1 for TwitterBroadcaster.

### DIFF
--- a/emulinker/src/main/java/org/emulinker/kaillera/lookingforgame/TwitterBroadcaster.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/lookingforgame/TwitterBroadcaster.kt
@@ -21,7 +21,10 @@ class TwitterBroadcaster
 @Inject
 internal constructor(private val flags: RuntimeFlags, private val twitter: Twitter) {
 
-  private val scope = CoroutineScope(Dispatchers.IO)
+  /** Dispatcher with maximum parallelism of 1. */
+  @OptIn(ExperimentalCoroutinesApi::class)
+  private val dispatcher = Dispatchers.IO.limitedParallelism(1)
+  private val scope = CoroutineScope(dispatcher)
 
   private val pendingReports: ConcurrentMap<LookingForGameEvent, Job> = ConcurrentHashMap()
   private val postedTweets: ConcurrentMap<LookingForGameEvent, Long> = ConcurrentHashMap()


### PR DESCRIPTION
This has the consequence that if users start games at the same time, their delays will stack instead of starting at the same time. This should be replaced with a `Channel` ideally in the future.